### PR TITLE
Fix Sass deprecation warnings in px functions

### DIFF
--- a/src/css/_functions/_px-to-em.scss
+++ b/src/css/_functions/_px-to-em.scss
@@ -3,7 +3,7 @@
 // @usage: em(24px, .875em) => 1.71429em
 //         em(24px, 16px) => 1,5em
 @function em($value: 14px, $default: 1em, $body: 16px) {
-    @if (unit($default) == "em") {
+    @if (math.unit($default) == "em") {
         $default: parse-int($default) * $body;
     }
 

--- a/src/css/_functions/_px-to-rem.scss
+++ b/src/css/_functions/_px-to-rem.scss
@@ -3,7 +3,7 @@
 // @usage: rem(24px, .875rem) => 1.71429rem
 //         rem(24px, 16px) => 1,5rem
 @function rem($value: 14px, $default: 1rem, $body: 16px) {
-    @if (unit($default) == "rem") {
+    @if (math.unit($default) == "rem") {
         $default: parse-int($default) * $body;
     }
 


### PR DESCRIPTION
## Summary
- use `math.unit` in custom `em` and `rem` helpers

## Testing
- `npm run dev` *(fails: gulp not found)*
- `npm run css-lint` *(fails: stylelint not found)*

------
https://chatgpt.com/codex/tasks/task_e_6863a1a879f8832bb053a1781d33f337