### PR TITLE
Fix layout on about page

### DIFF
--- a/src/html/about-us.html
+++ b/src/html/about-us.html
@@ -249,6 +249,7 @@
                 <!-- OTROS -->
 
                 </div>
+            </div>
         </div>
     </div>
 </div>


### PR DESCRIPTION
## Summary
- close an unclosed `<div>` in `about-us.html` to eliminate overlapping sections

## Testing
- `npm run css-lint` *(fails: stylelint not found)*
- `npm run js-lint` *(fails: ESLint configuration missing)*

------
https://chatgpt.com/codex/tasks/task_e_6863b779673c832b9738c54ff575ff64