### PR TITLE
Fix about-us layout spacing

### DIFF
--- a/src/html/about-us.html
+++ b/src/html/about-us.html
@@ -85,9 +85,9 @@
                 </div>
 
 
-                <hr class="mt-160 pb-8">
+                <hr class="mt-160 mb-8">
 
-                <div class="mb-n7">
+                <div>
                     <div class="row gv-2 justify-content-around text-center">
                         <div class="col-sm-6 col-md-auto">
                             <div class="number-box show-on-scroll" data-show-duration="500" data-show-distance="15" data-show-delay="50">
@@ -171,7 +171,7 @@
 </div>
 
 
-<div class="py-160">
+<div class="pt-160">
     <div class="container">
         <div class="row gv-5 align-items-center justify-content-between">
             <div class="col-12 col-lg-6">


### PR DESCRIPTION
## Summary
- adjust spacing for stats section in about-us page
- remove bottom padding on final section

## Testing
- `npm run css-lint` *(fails: stylelint not found)*
- `npm run js-lint` *(fails: ESLint couldn't find config)*

------
https://chatgpt.com/codex/tasks/task_e_6863bca160f8832bab4f97b4821e60e3